### PR TITLE
Fix Japanese title encoding

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,7 +40,7 @@ translations = {
         "savings_label": "Savings"
     },
     "ja": {
-        "app_title": "\ud83d\udcc8 10年間株価再生と貯蓄の重ね合わせ",
+        "app_title": "📈 10年間株価再生と貯蓄の重ね合わせ",
         "settings": "設定",
         "ticker_input": "ティッカー（Yahoo Financeのシンボル）",
         "years_of_history": "表示年数",


### PR DESCRIPTION
## Summary
- replace surrogate pair emoji in Japanese translation with proper Unicode character

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import ast
with open('app.py','r',encoding='utf-8') as f:
    mod=ast.parse(f.read())
for node in mod.body:
    if isinstance(node, ast.Assign):
        for target in node.targets:
            if isinstance(target, ast.Name) and target.id=='translations':
                translations=ast.literal_eval(node.value)
                break
s=translations['ja']['app_title']
print(s)
print(s.encode('utf-8'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689846f7d020832ab4a449deac6b50bb