### PR TITLE
feat: add mobile-friendly UI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # 10-Year Stock Replay & Savings Overlay
 
 Supports both English and Japanese interfaces. Use the sidebar to switch languages.
+You can also toggle between desktop and mobile layouts from the sidebar.
 
 ## Setup
 ```bash


### PR DESCRIPTION
## Summary
- add display mode toggle for desktop/mobile layouts
- simplify mobile view with optional advanced settings
- document layout toggle in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6898848af2d4832a847fd936e48c38e6