### PR TITLE
Improve ticker handling and savings display

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 Supports both English and Japanese interfaces. Use the sidebar to switch languages.
 You can also toggle between desktop and mobile layouts from the sidebar.
 
+The ticker selector includes popular U.S. stocks and Bitcoin by default, and you can
+enter any other Yahoo Finance symbol manually. Leaving the ticker blank shows a
+friendly warning instead of an error.
+
+The savings model now renders a visible blue line starting from zero, making it
+easy to compare contributions against price performance.
+
 ## Setup
 ```bash
 python -m venv venv


### PR DESCRIPTION
## Summary
- add popular ticker selector with custom input and warning for blank ticker
- display savings curve from zero and normalize correctly
- document new ticker handling and savings visibility

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689887e4f2d0832a9154fc28616263a8