### PR TITLE
Fix streamlit app relative imports

### DIFF
--- a/minervini_stage/app_streamlit.py
+++ b/minervini_stage/app_streamlit.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 
 import streamlit as st
 
-from .indicators import compute_indicators
-from .io_utils import LoadConfig, load_data
-from .plotter import plot_stages, plot_vcp
-from .stage_rules import StageConfig, classify_stage
-from .vcp import VCPConfig, detect_vcp
+try:  # pragma: no cover - runtime import fix
+    from .indicators import compute_indicators
+    from .io_utils import LoadConfig, load_data
+    from .plotter import plot_stages, plot_vcp
+    from .stage_rules import StageConfig, classify_stage
+    from .vcp import VCPConfig, detect_vcp
+except ImportError:  # executed when run as a script outside the package
+    from indicators import compute_indicators
+    from io_utils import LoadConfig, load_data
+    from plotter import plot_stages, plot_vcp
+    from stage_rules import StageConfig, classify_stage
+    from vcp import VCPConfig, detect_vcp
 
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ yfinance>=0.2.36
 plotly>=5.20.0
 pandas>=2.2.0
 numpy>=1.26.0
+matplotlib>=3.10


### PR DESCRIPTION
## Summary
- Make `app_streamlit.py` work when executed directly by trying both package and local imports
- Add missing `matplotlib` dependency required for plotting

## Testing
- `pytest`
- `python minervini_stage/app_streamlit.py` *(fails to fetch data but no import error)*

------
https://chatgpt.com/codex/tasks/task_e_689896bba968832abfd86d09fe878158