### PR TITLE
Add Streamlit one-year stage classification app

### DIFF
--- a/stage_app/README.md
+++ b/stage_app/README.md
@@ -1,0 +1,19 @@
+# Stage App (1Y)
+
+Streamlit application for Minervini-style market stage classification over the
+most recent year.
+
+## Quick start
+
+```bash
+python -m venv venv
+venv\Scripts\activate         # on Windows (or: source venv/bin/activate on macOS/Linux)
+pip install -r requirements.txt
+streamlit run stage_app/app.py
+```
+
+## Optional CLI
+
+```bash
+python -m stage_app.cli classify --ticker SPY --csv-out stages_1y.csv --suppress-warnings
+```

--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -1,0 +1,115 @@
+import warnings
+warnings.filterwarnings("ignore")
+
+from time import perf_counter
+from typing import List
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+import streamlit as st
+
+from stage_app.stage import (
+    STAGE_COLORS,
+    classify_stages,
+    compute_indicators,
+    fetch_price_data,
+)
+
+st.set_page_config(layout="wide")
+
+
+@st.cache_data(ttl=3600)
+def cached_fetch(ticker: str) -> pd.DataFrame:
+    return fetch_price_data(ticker)
+
+
+def build_chart(df: pd.DataFrame) -> go.Figure:
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=df.index,
+            y=df["Close"],
+            name="Close",
+            line=dict(color="blue"),
+            customdata=df["Stage"],
+            hovertemplate="Price: %{y:.2f}<br>Stage: %{customdata}<extra></extra>",
+        )
+    )
+
+    segments = []
+    start = df.index[0]
+    current = df["Stage"].iloc[0]
+    for idx, stage in df["Stage"].iloc[1:].items():
+        if stage != current:
+            segments.append((start, idx, current))
+            start = idx
+            current = stage
+    segments.append((start, df.index[-1], current))
+
+    for s, e, stage in segments:
+        color = STAGE_COLORS.get(stage, "white")
+        fig.add_vrect(x0=s, x1=e, fillcolor=color, opacity=0.1, line_width=0)
+
+    fig.update_layout(margin=dict(l=20, r=20, t=40, b=40))
+    return fig
+
+
+def main() -> None:
+    st.sidebar.header("Settings")
+    ticker = st.sidebar.text_input("Ticker", "SPY")
+    run_btn = st.sidebar.button("Run")
+
+    st.sidebar.markdown("### Stage Colors")
+    for s, c in STAGE_COLORS.items():
+        st.sidebar.markdown(
+            f"<span style='background-color:{c};padding:2px 8px;border-radius:3px;color:white;'>Stage {s}</span>",
+            unsafe_allow_html=True,
+        )
+
+    if not run_btn:
+        return
+
+    pbar = st.progress(0)
+    steps = 5
+    start_time = perf_counter()
+
+    # 1. Validate input
+    if not ticker:
+        st.warning("Please enter a ticker symbol.")
+        return
+    pbar.progress(int(100 / steps))
+
+    try:
+        # 2. Downloading data
+        with st.spinner("Downloading data..."):
+            data = cached_fetch(ticker)
+        pbar.progress(int(2 * 100 / steps))
+
+        # 3. Computing indicators
+        with st.spinner("Computing indicators..."):
+            df = compute_indicators(data)
+        pbar.progress(int(3 * 100 / steps))
+
+        # 4. Classifying stages
+        with st.spinner("Classifying stages..."):
+            df["Stage"] = classify_stages(df)
+        pbar.progress(int(4 * 100 / steps))
+
+        # 5. Rendering chart
+        with st.spinner("Rendering chart..."):
+            fig = build_chart(df.dropna())
+            st.plotly_chart(fig, use_container_width=True)
+            st.dataframe(
+                df[["Close", "SMA50", "SMA150", "SMA200", "Stage"]].dropna().tail(10)
+            )
+        pbar.progress(100)
+
+        total = perf_counter() - start_time
+        st.write(f"Completed in {total:.2f}s")
+    except Exception as exc:  # noqa: BLE001
+        st.warning(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/stage_app/cli.py
+++ b/stage_app/cli.py
@@ -1,0 +1,32 @@
+import warnings
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import typer
+
+from stage_app.stage import classify_stages, compute_indicators, fetch_price_data
+
+app = typer.Typer()
+
+
+@app.command()
+def classify(
+    ticker: str = typer.Option(..., help="Ticker symbol"),
+    csv_out: Path = typer.Option(..., help="Output CSV file"),
+    suppress_warnings: bool = typer.Option(False, "--suppress-warnings", help="Silence warnings"),
+) -> None:
+    """Export 1Y stage classification to CSV."""
+    if suppress_warnings:
+        warnings.filterwarnings("ignore")
+    data = fetch_price_data(ticker)
+    df = compute_indicators(data)
+    df["Stage"] = classify_stages(df)
+    df[["Close", "SMA50", "SMA150", "SMA200", "Stage"]].dropna().to_csv(
+        csv_out, index_label="Date"
+    )
+    typer.echo(f"Saved {csv_out}")
+
+
+if __name__ == "__main__":
+    app()

--- a/stage_app/requirements.txt
+++ b/stage_app/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+numpy
+yfinance
+plotly
+typer

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -1,0 +1,93 @@
+import warnings
+warnings.filterwarnings("ignore")
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+
+STAGE_COLORS = {1: "gray", 2: "green", 3: "orange", 4: "red"}
+
+
+def fetch_price_data(ticker: str, lookback_days: int = 380) -> pd.DataFrame:
+    """Fetch adjusted close prices for a ticker.
+
+    Downloads data for the last ``lookback_days`` calendar days and keeps the
+    most recent 252 trading days. Raises ``ValueError`` if fewer than 200 rows
+    remain after trimming.
+    """
+    end = datetime.utcnow()
+    start = end - timedelta(days=lookback_days)
+    data = yf.download(
+        ticker,
+        start=start,
+        end=end,
+        progress=False,
+        auto_adjust=True,
+    )
+    if data.empty:
+        raise ValueError("No data returned.")
+    data = data.tail(252)
+    if len(data) < 200:
+        raise ValueError(
+            "Not enough data to compute SMA200; need at least 200 trading days."
+        )
+    return data[["Close"]]
+
+
+def _sma_slope(series: pd.Series, window: int) -> pd.Series:
+    """Return slope of ``series`` over ``window`` using simple OLS."""
+    x = np.arange(window)
+
+    def _slope(y: np.ndarray) -> float:
+        return np.polyfit(x, y, 1)[0]
+
+    return series.rolling(window).apply(_slope, raw=True)
+
+
+def compute_indicators(data: pd.DataFrame, slope_window: int = 20) -> pd.DataFrame:
+    """Compute moving averages and 52w high/low."""
+    df = data.copy()
+    df["SMA50"] = df["Close"].rolling(50).mean()
+    df["SMA150"] = df["Close"].rolling(150).mean()
+    df["SMA200"] = df["Close"].rolling(200).mean()
+    df["High52w"] = df["Close"].rolling(252).max()
+    df["Low52w"] = df["Close"].rolling(252).min()
+    df["Slope200"] = _sma_slope(df["SMA200"], slope_window)
+    return df
+
+
+def classify_stages(df: pd.DataFrame, slope_threshold: float = 0.0) -> pd.Series:
+    """Classify market stages based on indicator data."""
+    stage = pd.Series(np.nan, index=df.index, dtype="float")
+
+    cond2 = (
+        (df["Close"] > df["SMA50"]) &
+        (df["Close"] > df["SMA150"]) &
+        (df["Close"] > df["SMA200"]) &
+        (df["SMA150"] > df["SMA200"]) &
+        (df["Slope200"] > slope_threshold) &
+        (df["Close"] >= df["Low52w"] * 1.30) &
+        (df["Close"] >= df["High52w"] * 0.75)
+    )
+
+    cond4 = (df["Close"] < df["SMA200"]) & (df["Slope200"] < slope_threshold)
+
+    cond3 = (
+        (df["Close"] < df["SMA50"]) &
+        (df["Close"] < df["SMA150"]) &
+        (df["Close"] >= df["SMA200"]) &
+        (df["Slope200"] <= slope_threshold)
+    )
+
+    cond1 = (df["Close"] <= df["SMA200"]) & (df["Slope200"] >= slope_threshold)
+
+    stage[cond2] = 2
+    stage[cond4 & stage.isna()] = 4
+    stage[cond3 & stage.isna()] = 3
+    stage[cond1 & stage.isna()] = 1
+
+    return stage


### PR DESCRIPTION
## Summary
- add standalone `stage_app` with Streamlit UI for one-year Minervini stage classification
- include indicator computations and stage logic utilities
- provide optional CLI, requirements, and README with quick-start instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a47cb308832a9c125f94b2a15bbc