### PR TITLE
Fix CLI command and Streamlit imports

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -2,14 +2,13 @@ import warnings
 warnings.filterwarnings("ignore")
 
 from time import perf_counter
-from typing import List
 
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-from stage_app.stage import (
+from .stage import (
     STAGE_COLORS,
     classify_stages,
     compute_indicators,

--- a/stage_app/cli.py
+++ b/stage_app/cli.py
@@ -1,20 +1,25 @@
 import warnings
 from pathlib import Path
-from typing import Optional
 
-import pandas as pd
 import typer
 
-from stage_app.stage import classify_stages, compute_indicators, fetch_price_data
+from .stage import classify_stages, compute_indicators, fetch_price_data
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.callback()
+def main() -> None:
+    """Stage classification utilities."""
 
 
 @app.command()
 def classify(
     ticker: str = typer.Option(..., help="Ticker symbol"),
     csv_out: Path = typer.Option(..., help="Output CSV file"),
-    suppress_warnings: bool = typer.Option(False, "--suppress-warnings", help="Silence warnings"),
+    suppress_warnings: bool = typer.Option(
+        False, "--suppress-warnings", help="Silence warnings"
+    ),
 ) -> None:
     """Export 1Y stage classification to CSV."""
     if suppress_warnings:


### PR DESCRIPTION
## Summary
- Expose `classify` as a subcommand in `stage_app.cli` and use relative imports
- Use relative imports in Streamlit app to avoid `ModuleNotFoundError`

## Testing
- `python -m stage_app.cli classify --ticker SPY --csv-out stages_1y.csv --suppress-warnings` (fails: No data returned)
- `streamlit run stage_app/app.py --server.headless true --server.port 8501`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898ab15a848832aab8a845c92e8669a