### PR TITLE
Handle MultiIndex columns from price downloads

### DIFF
--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -35,7 +35,19 @@ def fetch_price_data(ticker: str, lookback_days: int = 380) -> pd.DataFrame:
         raise ValueError(
             "Not enough data to compute SMA200; need at least 200 trading days."
         )
-    return data[["Close"]]
+
+    if isinstance(data.columns, pd.MultiIndex):
+        close = data.xs("Close", axis=1, level=0)
+        if isinstance(close, pd.Series):
+            close = close.to_frame("Close")
+        else:
+            close.columns = ["Close"]
+        data = close
+    else:
+        if "Close" not in data.columns:
+            raise ValueError("Downloaded data missing 'Close' column.")
+        data = data[["Close"]]
+    return data
 
 
 def _sma_slope(series: pd.Series, window: int) -> pd.Series:

--- a/tests/test_fetch_price_data.py
+++ b/tests/test_fetch_price_data.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import numpy as np
+import yfinance as yf
+
+from stage_app.stage import fetch_price_data
+
+
+def test_fetch_price_data_flattens_multiindex_columns(monkeypatch):
+    idx = pd.date_range("2023-01-01", periods=252, freq="B")
+    cols = pd.MultiIndex.from_product([["Close"], ["SPY"]], names=["Price", "Ticker"])
+    data = pd.DataFrame(np.arange(len(idx)), index=idx, columns=cols)
+
+    def fake_download(*args, **kwargs):
+        return data
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    df = fetch_price_data("SPY")
+    assert list(df.columns) == ["Close"]
+    assert len(df) == 252


### PR DESCRIPTION
## Summary
- Flatten MultiIndex columns in `fetch_price_data` to ensure a single `Close` column
- Add regression test covering MultiIndex column handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b43bf9f0832aa56c3c24906597f8