### PR TITLE
Fix stage app imports for standalone execution

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -8,7 +8,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-from .stage import (
+from stage_app.stage import (
     STAGE_COLORS,
     classify_stages,
     compute_indicators,

--- a/stage_app/cli.py
+++ b/stage_app/cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import typer
 
-from .stage import classify_stages, compute_indicators, fetch_price_data
+from stage_app.stage import classify_stages, compute_indicators, fetch_price_data
 
 app = typer.Typer(no_args_is_help=True)
 


### PR DESCRIPTION
## Summary
- use absolute package imports in Streamlit app to avoid relative import errors
- update CLI to match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b8549a74832a9b8f27b4c56cc813