### PR TITLE
Handle stage_app imports when running Streamlit

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -8,12 +8,20 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-from stage_app.stage import (
-    STAGE_COLORS,
-    classify_stages,
-    compute_indicators,
-    fetch_price_data,
-)
+try:  # Attempt absolute import when package is installed
+    from stage_app.stage import (
+        STAGE_COLORS,
+        classify_stages,
+        compute_indicators,
+        fetch_price_data,
+    )
+except ModuleNotFoundError:  # Fallback for running as a script
+    from stage import (
+        STAGE_COLORS,
+        classify_stages,
+        compute_indicators,
+        fetch_price_data,
+    )
 
 st.set_page_config(layout="wide")
 


### PR DESCRIPTION
## Summary
- make `stage_app.app` robust to being run as a script or installed package by trying both absolute and local imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898b9b77fbc832a80bf41ca55963b5a