### PR TITLE
feat: add NVDA stage visualization

### DIFF
--- a/tests/test_fetch_price_data.py
+++ b/tests/test_fetch_price_data.py
@@ -7,13 +7,14 @@ from stage_app.stage import fetch_price_data
 
 def test_fetch_price_data_flattens_multiindex_columns(monkeypatch):
     idx = pd.date_range("2023-01-01", periods=252, freq="B")
-    cols = pd.MultiIndex.from_product([["Close"], ["SPY"]], names=["Price", "Ticker"])
-    data = pd.DataFrame(np.arange(len(idx)), index=idx, columns=cols)
+    arrays = [["Open", "High", "Low", "Close", "Volume"], ["SPY"]]
+    cols = pd.MultiIndex.from_product(arrays, names=["Price", "Ticker"])
+    data = pd.DataFrame(np.arange(len(idx) * 5).reshape(len(idx), 5), index=idx, columns=cols)
 
     def fake_download(*args, **kwargs):
         return data
 
     monkeypatch.setattr(yf, "download", fake_download)
     df = fetch_price_data("SPY")
-    assert list(df.columns) == ["Close"]
+    assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
     assert len(df) == 252


### PR DESCRIPTION
## Summary
- fetch NVDA OHLC data with caching and stage classification
- show candlestick chart with monthly stage shading
- update tests for new OHLC data handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c7ced140832a95e8c89a6406a433