### PR TITLE
Add SMA overlays and ticker selector

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -8,14 +8,15 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-try:  # Attempt absolute import when package is installed
+# パッケージ/単体スクリプト両対応
+try:
     from stage_app.stage import (
         STAGE_COLORS,
         classify_stages,
         compute_indicators,
         fetch_price_data,
     )
-except ModuleNotFoundError:  # Fallback for running as a script
+except ModuleNotFoundError:
     from stage import (
         STAGE_COLORS,
         classify_stages,
@@ -24,7 +25,6 @@ except ModuleNotFoundError:  # Fallback for running as a script
     )
 
 st.set_page_config(layout="wide")
-
 
 CHOICES = {
     "NVIDIA (NVDA)": "NVDA",
@@ -47,19 +47,6 @@ def build_chart(df: pd.DataFrame, ticker: str) -> go.Figure:
     if df.empty:
         raise ValueError("No rows with computed Stage yet. Need enough data to compute indicators.")
 
-    hovertext = (
-        "Open "
-        + df["Open"].round(2).astype(str)
-        + "<br>High "
-        + df["High"].round(2).astype(str)
-        + "<br>Low "
-        + df["Low"].round(2).astype(str)
-        + "<br>Close "
-        + df["Close"].round(2).astype(str)
-        + "<br>Stage "
-        + df["Stage"].astype(int).astype(str)
-    )
-
     fig = go.Figure(
         data=[
             go.Candlestick(
@@ -69,7 +56,13 @@ def build_chart(df: pd.DataFrame, ticker: str) -> go.Figure:
                 low=df["Low"],
                 close=df["Close"],
                 name=ticker,
-                text=hovertext,
+                customdata=df["Stage"],
+                hovertext=[
+                    f"Open {o:.2f}<br>High {h:.2f}<br>Low {l:.2f}<br>Close {c:.2f}<br>Stage {int(s) if pd.notna(s) else 'NA'}"
+                    for o, h, l, c, s in zip(
+                        df["Open"], df["High"], df["Low"], df["Close"], df["Stage"]
+                    )
+                ],
                 hoverinfo="text",
             )
         ]
@@ -90,32 +83,37 @@ def build_chart(df: pd.DataFrame, ticker: str) -> go.Figure:
             )
         )
 
-    # 月ごとの区間塗り分け。月内の最頻値ステージを代表値として採用。
-    groups = df.groupby(df.index.to_period("M"))
-    bounds = [(g.index[0], g.index[-1]) for _, g in groups]
-    stage_mode = groups["Stage"].agg(lambda s: s.mode().iloc[0] if not s.mode().empty else np.nan).values
-    for (start, end), stage in zip(bounds, stage_mode):
-        color = STAGE_COLORS.get(stage, "white")
+    monthly = df["Stage"].resample("MS").apply(
+        lambda s: s.mode().iloc[0] if not s.dropna().empty else np.nan
+    )
+    month_starts = monthly.index.to_list()
+    for i, ms in enumerate(month_starts):
+        stg = monthly.iloc[i]
+        if pd.isna(stg):
+            continue
+        x0 = ms
+        x1 = month_starts[i + 1] if i + 1 < len(month_starts) else df.index[-1]
+        color = STAGE_COLORS.get(int(stg), "white")
         fig.add_vrect(
-            x0=start,
-            x1=end,
-            fillcolor=color,
-            opacity=0.1,
-            line_width=0,
-            layer="below",
+            x0=x0, x1=x1, fillcolor=color, opacity=0.10, line_width=0, layer="below"
         )
 
-    fig.update_layout(margin=dict(l=20, r=20, t=40, b=40), xaxis_rangeslider_visible=False)
+    fig.update_layout(
+        margin=dict(l=20, r=20, t=40, b=40),
+        xaxis_rangeslider_visible=False,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
     return fig
 
 
-
 def main() -> None:
+    # ===== サイドバー =====
     st.sidebar.header("Settings")
     label = st.sidebar.selectbox("Ticker", list(CHOICES.keys()), index=0)
     ticker = CHOICES[label]
     years = st.sidebar.number_input("期間（年数）", 1, 10, 1, 1)
     run_btn = st.sidebar.button("Run")
+
     st.sidebar.markdown("### Stage Colors")
     for s, c in STAGE_COLORS.items():
         st.sidebar.markdown(
@@ -123,49 +121,51 @@ def main() -> None:
             unsafe_allow_html=True,
         )
 
+    if not run_btn:
+        st.info("左の設定を選んで『Run』を押してください。")
+        return
+
     pbar = st.progress(0)
     steps = 4
-    start_time = perf_counter()
+    t0 = perf_counter()
 
     try:
-        if run_btn or "df" not in st.session_state:
+        # 1) データ取得（年数→暦日換算。余裕を持って365*years日）
+        with st.spinner("Downloading data..."):
             lookback_days = int(years * 365)
-            with st.spinner("Downloading data..."):
-                data = cached_fetch(ticker, lookback_days)
-            pbar.progress(int(1 * 100 / steps))
+            data = cached_fetch(ticker, lookback_days=lookback_days)
+        pbar.progress(int(1 * 100 / steps))
 
-            with st.spinner("Computing indicators..."):
-                df = compute_indicators(data)
-            pbar.progress(int(2 * 100 / steps))
+        # 2) 指標計算（Closeベース）
+        with st.spinner("Computing indicators..."):
+            df = compute_indicators(data)
+        pbar.progress(int(2 * 100 / steps))
 
-            with st.spinner("Classifying stages..."):
-                df["Stage"] = classify_stages(df)
-            pbar.progress(int(3 * 100 / steps))
+        # 3) ステージ分類
+        with st.spinner("Classifying stages..."):
+            df["Stage"] = classify_stages(df)
+        pbar.progress(int(3 * 100 / steps))
 
-            df = df.dropna(subset=["Open", "High", "Low", "Close", "Stage"])
-            st.session_state["df"] = df
-
-        df = st.session_state.get("df", pd.DataFrame())
-
+        # 4) 描画
         with st.spinner("Rendering chart..."):
-            if df.empty:
+            need = ["Open", "High", "Low", "Close", "Stage"]
+            df_plot = df.dropna(subset=need).copy()
+            if df_plot.empty:
                 st.info("まだステージが計算できた行がありません（SMAや200日傾きの計算に十分な日数が必要です）。")
             else:
-                fig = build_chart(df, ticker)
+                fig = build_chart(df_plot, ticker)
                 st.plotly_chart(fig, use_container_width=True)
-
-            tbl = (
-                df[["Close", "SMA25", "SMA50", "SMA200", "Stage"]]
-                .dropna(subset=["SMA25", "SMA50", "SMA200", "Stage"])
-                .tail(10)
-            )
-            st.dataframe(tbl)
+                tbl = (
+                    df[["Close", "SMA25", "SMA50", "SMA200", "Stage"]]
+                    .dropna(subset=["SMA25", "SMA50", "SMA200", "Stage"])
+                    .tail(10)
+                )
+                st.dataframe(tbl)
 
         pbar.progress(100)
+        st.write(f"Completed in {perf_counter() - t0:.2f}s")
 
-        total = perf_counter() - start_time
-        st.write(f"Completed in {total:.2f}s")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # 取得失敗や列欠損などはここで通知
         st.warning(str(exc))
 
 

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -5,14 +5,11 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
-import streamlit as st
 import yfinance as yf
 
 
 STAGE_COLORS = {1: "gray", 2: "green", 3: "orange", 4: "red"}
 
-
-@st.cache_data(ttl=3600)
 def fetch_price_data(ticker: str = "NVDA", lookback_days: int = 380) -> pd.DataFrame:
     """Fetch OHLC data for ``ticker`` and keep the latest 252 trading days.
 
@@ -62,6 +59,7 @@ def _sma_slope(series: pd.Series, window: int) -> pd.Series:
 def compute_indicators(data: pd.DataFrame, slope_window: int = 20) -> pd.DataFrame:
     """Compute moving averages and 52w high/low."""
     df = data.copy()
+    df["SMA25"] = df["Close"].rolling(25).mean()
     df["SMA50"] = df["Close"].rolling(50).mean()
     df["SMA150"] = df["Close"].rolling(150).mean()
     df["SMA200"] = df["Close"].rolling(200).mean()

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -10,40 +10,64 @@ import yfinance as yf
 
 STAGE_COLORS = {1: "gray", 2: "green", 3: "orange", 4: "red"}
 
-def fetch_price_data(ticker: str = "NVDA", lookback_days: int = 380) -> pd.DataFrame:
-    """Fetch OHLC data for ``ticker`` and keep the latest 252 trading days.
 
-    Columns are flattened if a MultiIndex is returned by ``yfinance`` and only
-    ``Open``, ``High``, ``Low``, ``Close`` and ``Volume`` are kept. Raises
-    ``ValueError`` if fewer than 200 rows remain after trimming.
-    """
+def fetch_price_data(ticker: str, lookback_days: int = 380) -> pd.DataFrame:
+    """Return OHLC for last ~1y (252 trading days). Robust to Yahoo quirks."""
     end = datetime.utcnow()
     start = end - timedelta(days=lookback_days)
-    data = yf.download(
-        ticker,
-        start=start,
-        end=end,
-        progress=False,
-        auto_adjust=True,
-    )
-    if data.empty:
-        raise ValueError("No data returned.")
 
-    data = data.tail(252)
-    if len(data) < 200:
-        raise ValueError(
-            "Not enough data to compute SMA200; need at least 200 trading days."
+    # 1) まず Ticker().history() を試す（こっちの方が列崩れしにくい）
+    try:
+        data = yf.Ticker(ticker).history(
+            start=start, end=end, auto_adjust=True, interval="1d"
+        )
+    except Exception:
+        data = pd.DataFrame()
+
+    # 2) ダメなら download() にフォールバック
+    if data is None or data.empty:
+        data = yf.download(
+            ticker, start=start, end=end, auto_adjust=True, progress=False, interval="1d"
         )
 
+    if data is None or data.empty:
+        raise ValueError("No data returned from Yahoo Finance.")
+
+    # 列をフラット化
     if isinstance(data.columns, pd.MultiIndex):
-        # Flatten MultiIndex columns (e.g. ('Close', 'NVDA') -> 'Close')
         data.columns = data.columns.get_level_values(0)
 
-    required = ["Open", "High", "Low", "Close", "Volume"]
-    missing = [c for c in required if c not in data.columns]
-    if missing:
-        raise ValueError(f"Downloaded data missing columns: {missing}")
-    return data[required]
+    # 列名の大小文字ぶれ対策
+    cols = {c.lower(): c for c in data.columns}
+    have = {k: cols.get(k) for k in ["open", "high", "low", "close", "volume"]}
+
+    # 3) OHLC が揃っていればそれを使用（Volume があれば併せて返す）
+    if all(have[k] for k in ["open", "high", "low", "close"]):
+        keep = [have["open"], have["high"], have["low"], have["close"]]
+        headers = ["Open", "High", "Low", "Close"]
+        if have["volume"]:
+            keep.append(have["volume"])
+            headers.append("Volume")
+        data = data[keep]
+        data.columns = headers
+    else:
+        # 4) 最低限のフォールバック：Close から擬似 OHLC を作る
+        #    （ローソク足は描けるが上下ヒゲは出ない）
+        close_col = have["close"] or cols.get("adj close") or cols.get("adjclose")
+        if not close_col:
+            raise ValueError(f"Downloaded data missing columns: ['Open','High','Low','Close']")
+        c = data[close_col].astype(float)
+        data = pd.DataFrame(
+            {"Open": c, "High": c, "Low": c, "Close": c}, index=data.index
+        )
+
+    # 直近252本に絞る
+    data = data.tail(252)
+    if len(data) < 200:
+        raise ValueError("Not enough data to compute SMA200; need ≥200 trading days.")
+    data.index.name = "Date"
+    return data
+
 
 
 def _sma_slope(series: pd.Series, window: int) -> pd.Series:


### PR DESCRIPTION
## Summary
- overlay SMA25/50/200 lines on candlestick chart
- allow choosing NVDA, Magnificent 7 and BTC-USD via sidebar
- refresh cached price data by ticker and lookback window
- shade monthly stage regions using the most frequent stage value

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d29f70c4832a9052f963790f7afa