### PR TITLE
Add SMA overlays and ticker selector

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -8,14 +8,15 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
-try:  # Attempt absolute import when package is installed
+# パッケージ/単体スクリプト両対応
+try:
     from stage_app.stage import (
         STAGE_COLORS,
         classify_stages,
         compute_indicators,
         fetch_price_data,
     )
-except ModuleNotFoundError:  # Fallback for running as a script
+except ModuleNotFoundError:
     from stage import (
         STAGE_COLORS,
         classify_stages,
@@ -25,8 +26,24 @@ except ModuleNotFoundError:  # Fallback for running as a script
 
 st.set_page_config(layout="wide")
 
+CHOICES = {
+    "NVIDIA (NVDA)": "NVDA",
+    "Apple (AAPL)": "AAPL",
+    "Microsoft (MSFT)": "MSFT",
+    "Amazon (AMZN)": "AMZN",
+    "Alphabet (GOOGL)": "GOOGL",
+    "Meta (META)": "META",
+    "Tesla (TSLA)": "TSLA",
+    "Bitcoin (BTC-USD)": "BTC-USD",
+}
 
-def build_chart(df: pd.DataFrame) -> go.Figure:
+
+@st.cache_data(ttl=1800)
+def cached_fetch(ticker: str, lookback_days: int) -> pd.DataFrame:
+    return fetch_price_data(ticker, lookback_days=lookback_days)
+
+
+def build_chart(df: pd.DataFrame, ticker: str) -> go.Figure:
     if df.empty:
         raise ValueError("No rows with computed Stage yet. Need enough data to compute indicators.")
 
@@ -38,86 +55,117 @@ def build_chart(df: pd.DataFrame) -> go.Figure:
                 high=df["High"],
                 low=df["Low"],
                 close=df["Close"],
-                name="NVDA",
+                name=ticker,
                 customdata=df["Stage"],
-                hovertemplate="Open %{open:.2f}<br>High %{high:.2f}<br>Low %{low:.2f}<br>Close %{close:.2f}<br>Stage %{customdata}<extra></extra>",
+                hovertext=[
+                    f"Open {o:.2f}<br>High {h:.2f}<br>Low {l:.2f}<br>Close {c:.2f}<br>Stage {int(s) if pd.notna(s) else 'NA'}"
+                    for o, h, l, c, s in zip(
+                        df["Open"], df["High"], df["Low"], df["Close"], df["Stage"]
+                    )
+                ],
+                hoverinfo="text",
             )
         ]
     )
 
-    # 月ごとの区間塗り分け。月末のステージで代表させる。
-    groups = df.groupby(df.index.to_period("M"))
-    bounds = [(g.index[0], g.index[-1]) for _, g in groups]
-    month_ends = [b[1] for b in bounds]
-    stage_last = df["Stage"].resample("M").last().reindex(month_ends)
-    for (start, end), stage in zip(bounds, stage_last):
-        color = STAGE_COLORS.get(stage, "white")
-        fig.add_vrect(
-            x0=start,
-            x1=end,
-            fillcolor=color,
-            opacity=0.1,
-            line_width=0,
-            layer="below",
+    for name, color in [
+        ("SMA25", "blue"),
+        ("SMA50", "orange"),
+        ("SMA200", "purple"),
+    ]:
+        fig.add_trace(
+            go.Scatter(
+                x=df.index,
+                y=df[name],
+                name=name,
+                mode="lines",
+                line=dict(color=color),
+            )
         )
 
-    fig.update_layout(margin=dict(l=20, r=20, t=40, b=40), xaxis_rangeslider_visible=False)
+    monthly = df["Stage"].resample("MS").apply(
+        lambda s: s.mode().iloc[0] if not s.dropna().empty else np.nan
+    )
+    month_starts = monthly.index.to_list()
+    for i, ms in enumerate(month_starts):
+        stg = monthly.iloc[i]
+        if pd.isna(stg):
+            continue
+        x0 = ms
+        x1 = month_starts[i + 1] if i + 1 < len(month_starts) else df.index[-1]
+        color = STAGE_COLORS.get(int(stg), "white")
+        fig.add_vrect(
+            x0=x0, x1=x1, fillcolor=color, opacity=0.10, line_width=0, layer="below"
+        )
+
+    fig.update_layout(
+        margin=dict(l=20, r=20, t=40, b=40),
+        xaxis_rangeslider_visible=False,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
     return fig
 
 
-
 def main() -> None:
+    # ===== サイドバー =====
     st.sidebar.header("Settings")
-    st.sidebar.markdown("Ticker: NVDA")
+    label = st.sidebar.selectbox("Ticker", list(CHOICES.keys()), index=0)
+    ticker = CHOICES[label]
+    years = st.sidebar.number_input("期間（年数）", 1, 10, 1, 1)
+    run_btn = st.sidebar.button("Run")
+
     st.sidebar.markdown("### Stage Colors")
     for s, c in STAGE_COLORS.items():
         st.sidebar.markdown(
             f"<span style='background-color:{c};padding:2px 8px;border-radius:3px;color:white;'>Stage {s}</span>",
             unsafe_allow_html=True,
         )
-    ticker = "NVDA"
+
+    if not run_btn:
+        st.info("左の設定を選んで『Run』を押してください。")
+        return
 
     pbar = st.progress(0)
     steps = 4
-    start_time = perf_counter()
+    t0 = perf_counter()
 
     try:
-        # 1. Downloading data
+        # 1) データ取得（年数→暦日換算。余裕を持って365*years日）
         with st.spinner("Downloading data..."):
-            data = fetch_price_data(ticker)
+            lookback_days = int(years * 365)
+            data = cached_fetch(ticker, lookback_days=lookback_days)
         pbar.progress(int(1 * 100 / steps))
 
-        # 2. Computing indicators
+        # 2) 指標計算（Closeベース）
         with st.spinner("Computing indicators..."):
             df = compute_indicators(data)
         pbar.progress(int(2 * 100 / steps))
 
-        # 3. Classifying stages
+        # 3) ステージ分類
         with st.spinner("Classifying stages..."):
             df["Stage"] = classify_stages(df)
         pbar.progress(int(3 * 100 / steps))
 
-        # 4. Rendering chart
+        # 4) 描画
         with st.spinner("Rendering chart..."):
-            df_plot = df.dropna(subset=["Stage"]).copy()
+            need = ["Open", "High", "Low", "Close", "Stage"]
+            df_plot = df.dropna(subset=need).copy()
             if df_plot.empty:
                 st.info("まだステージが計算できた行がありません（SMAや200日傾きの計算に十分な日数が必要です）。")
             else:
-                fig = build_chart(df_plot)
+                fig = build_chart(df_plot, ticker)
                 st.plotly_chart(fig, use_container_width=True)
-
-            tbl = (
-                df[["Close", "SMA50", "SMA150", "SMA200", "Stage"]]
-                .dropna(subset=["SMA50", "SMA150", "SMA200", "Stage"])
-                .tail(10)
-            )
-            st.dataframe(tbl)
+                tbl = (
+                    df[["Close", "SMA25", "SMA50", "SMA200", "Stage"]]
+                    .dropna(subset=["SMA25", "SMA50", "SMA200", "Stage"])
+                    .tail(10)
+                )
+                st.dataframe(tbl)
 
         pbar.progress(100)
+        st.write(f"Completed in {perf_counter() - t0:.2f}s")
 
-        total = perf_counter() - start_time
-        st.write(f"Completed in {total:.2f}s")
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # 取得失敗や列欠損などはここで通知
         st.warning(str(exc))
 
 


### PR DESCRIPTION
## Summary
- overlay SMA25/50/200 lines on candlestick chart
- allow choosing NVDA, Magnificent 7 and BTC-USD via sidebar
- refresh cached price data by ticker and lookback window
- shade monthly stage regions using the most frequent stage value

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d29f70c4832a9052f963790f7afa