### PR TITLE
Fix 1-year period display retaining full data range

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -148,7 +148,9 @@ def main() -> None:
 
         # 4) 描画
         with st.spinner("Rendering chart..."):
-            need = ["Open", "High", "Low", "Close", "Stage"]
+            # Stage 列の NaN でフィルタすると初期データが消えてしまうため、
+            # OHLC が揃っているかのみ確認する
+            need = ["Open", "High", "Low", "Close"]
             df_plot = df.dropna(subset=need).copy()
             if df_plot.empty:
                 st.info("まだステージが計算できた行がありません（SMAや200日傾きの計算に十分な日数が必要です）。")

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -12,7 +12,12 @@ STAGE_COLORS = {1: "gray", 2: "green", 3: "orange", 4: "red"}
 
 
 def fetch_price_data(ticker: str, lookback_days: int = 380) -> pd.DataFrame:
-    """Return OHLC for last ~1y (252 trading days). Robust to Yahoo quirks."""
+    """Return OHLC data for the requested lookback window.
+
+    ``lookback_days`` specifies how many calendar days to retrieve, which allows
+    the caller to control the visible history (e.g. 1–5 years).  The function
+    is robust to common Yahoo Finance quirks.
+    """
     end = datetime.utcnow()
     start = end - timedelta(days=lookback_days)
 
@@ -61,8 +66,6 @@ def fetch_price_data(ticker: str, lookback_days: int = 380) -> pd.DataFrame:
             {"Open": c, "High": c, "Low": c, "Close": c}, index=data.index
         )
 
-    # 直近252本に絞る
-    data = data.tail(252)
     if len(data) < 200:
         raise ValueError("Not enough data to compute SMA200; need ≥200 trading days.")
     data.index.name = "Date"


### PR DESCRIPTION
## Summary
- allow fetching full lookback range rather than truncating to 252 days
- render charts without dropping rows where Stage is NaN to preserve initial data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689968a15578832aa03c76ad306aedcb