### PR TITLE
Fix 1‑year range and Stage4 classification

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -103,6 +103,8 @@ def build_chart(df: pd.DataFrame, ticker: str) -> go.Figure:
         xaxis_rangeslider_visible=False,
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
     )
+    # X軸は受け取ったデータ範囲をそのまま表示する（NaNによる短縮を防止）
+    fig.update_xaxes(range=[df.index.min(), df.index.max()])
     return fig
 
 

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -88,9 +88,12 @@ def compute_indicators(data: pd.DataFrame, slope_window: int = 20) -> pd.DataFra
     df["Slope200"] = _sma_slope(df["SMA200"], slope_window)
     return df
 
-def classify_stages(df: pd.DataFrame, slope_threshold: float = 0.0) -> pd.Series:
+def classify_stages(df: pd.DataFrame, slope_threshold: float = -1e-9) -> pd.Series:
     """Minervini 1/2/3/4 判定（Stage3 を優先）。
     優先度: 2(厳格) ＞ 3 ＞ 4 ＞ 1 ＞ 2(基本)
+
+    ``slope_threshold`` は微小なノイズで上向き判定になることを防ぐため、
+    ごく僅かに負の値をデフォルトとする。
     """
     df = df.copy()
     if isinstance(df.index, pd.MultiIndex):
@@ -102,7 +105,8 @@ def classify_stages(df: pd.DataFrame, slope_threshold: float = 0.0) -> pd.Series
     sma50   = df["SMA50"].squeeze()
     sma150  = df["SMA150"].squeeze()
     sma200  = df["SMA200"].squeeze()
-    slope   = df["Slope200"].squeeze()
+    # 200日線の傾きは短期平均で平滑化してから符号判定する
+    slope   = df["Slope200"].rolling(5).mean().squeeze()
     high52w = df["High52w"].squeeze()
     low52w  = df["Low52w"].squeeze()
 


### PR DESCRIPTION
## Summary
- Always display the full requested date range on candlestick charts
- Smooth the 200‑day slope and use a tiny negative threshold so Stage4 is prioritized over Stage1

## Testing
- `pytest -q`
- `python - <<'PY'
from stage_app.stage import fetch_price_data, compute_indicators, classify_stages
import pandas as pd
try:
    data=fetch_price_data('AAPL', lookback_days=int(2*365))
    df=compute_indicators(data)
    df['Stage']=classify_stages(df)
except Exception as e:
    print(e)
PY` *(fails: No data returned from Yahoo Finance)*
- `python - <<'PY'
import pandas as pd
from stage_app.stage import classify_stages
index = pd.date_range('2024-01-01', periods=5)
df = pd.DataFrame({'Close':[100]*5,'SMA50':[110]*5,'SMA150':[120]*5,'SMA200':[130]*5,'Slope200':[-0.5]*5,'High52w':[150]*5,'Low52w':[90]*5}, index=index)
print(classify_stages(df))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68996bb8a908832a87905cce8284baca