### PR TITLE
Add regression tests for Minervini stage detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ streamlit run stage_app/app.py
 ```bash
 python -m stage_app.cli classify --ticker SPY --csv-out stages_1y.csv --suppress-warnings
 ```
+## Run tests
+```bash
+python -m venv venv
+venv\Scripts\activate            # Windows (or: source venv/bin/activate)
+pip install -r requirements.txt  # app deps
+pip install -r requirements-dev.txt
+pytest -q
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+yfinance
+pandas
+numpy
+plotly

--- a/tests/golden_windows.yaml
+++ b/tests/golden_windows.yaml
@@ -1,0 +1,25 @@
+[
+  {
+    "name": "NVDA_1Y_continuity",
+    "ticker": "NVDA",
+    "years": 1,
+    "expect": {
+      "min_trading_days": 240,
+      "require_sma200_coverage_days": 200,
+      "allow_stage_nan_ratio": 0.05
+    }
+  },
+  {
+    "name": "AAPL_20250314_20250409_stage4",
+    "ticker": "AAPL",
+    "window": {
+      "start": "2025-03-14",
+      "end": "2025-04-09"
+    },
+    "expect": {
+      "stage": 4,
+      "method": "majority",
+      "min_ratio": 0.6
+    }
+  }
+]

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+from datetime import datetime
+import pandas as pd
+import pytest
+
+# Try importing from either stage or stage_app.stage
+try:
+    from stage import fetch_price_data, compute_indicators, classify_stages  # type: ignore
+except Exception:  # pragma: no cover
+    from stage_app.stage import fetch_price_data, compute_indicators, classify_stages
+
+BASE_DIR = Path(__file__).resolve().parent
+GOLDEN_PATH = BASE_DIR / "golden_windows.yaml"
+ARTIFACTS_DIR = BASE_DIR / "artifacts"
+ARTIFACTS_DIR.mkdir(exist_ok=True)
+
+with GOLDEN_PATH.open() as f:
+    GOLDEN_WINDOWS = json.load(f)
+
+
+def _save_debug(df: pd.DataFrame, name: str, columns: list[str]) -> Path:
+    path = ARTIFACTS_DIR / f"{name}_debug.csv"
+    df[columns].to_csv(path)
+    return path
+
+
+def _run_continuity(cfg: dict) -> None:
+    years = cfg["years"]
+    exp = cfg["expect"]
+    lookback = years * 365 + 300
+    df = fetch_price_data(cfg["ticker"], lookback_days=lookback)
+    df = compute_indicators(df)
+    df["Stage"] = classify_stages(df)
+    end_date = df.index.max()
+    start_date = end_date - pd.Timedelta(days=years * 365)
+    recent = df.loc[start_date:]
+
+    if len(recent) < exp["min_trading_days"]:
+        path = _save_debug(recent, cfg["name"], ["Open","High","Low","Close","SMA25","SMA50","SMA150","SMA200","Stage"])
+        pytest.fail(
+            f"{len(recent)} trading days found (<{exp['min_trading_days']}). Debug CSV: {path}"
+        )
+
+    coverage = recent.tail(exp["require_sma200_coverage_days"])
+    if coverage["SMA200"].isna().any():
+        missing = int(coverage["SMA200"].isna().sum())
+        path = _save_debug(recent, cfg["name"], ["Open","High","Low","Close","SMA25","SMA50","SMA150","SMA200","Stage"])
+        pytest.fail(
+            f"SMA200 has {missing} NaNs in last {exp['require_sma200_coverage_days']} days. Debug CSV: {path}"
+        )
+
+    nan_ratio = float(recent["Stage"].isna().mean())
+    if nan_ratio > exp["allow_stage_nan_ratio"]:
+        path = _save_debug(recent, cfg["name"], ["Open","High","Low","Close","SMA25","SMA50","SMA150","SMA200","Stage"])
+        pytest.fail(
+            f"Stage NaN ratio {nan_ratio:.2%} exceeds {exp['allow_stage_nan_ratio']:.2%}. Debug CSV: {path}"
+        )
+
+
+def _run_stage_window(cfg: dict) -> None:
+    window = cfg["window"]
+    exp = cfg["expect"]
+    start = pd.to_datetime(window["start"])
+    end = pd.to_datetime(window["end"])
+    lookback = (datetime.utcnow().date() - start.date()).days + 300
+    df = fetch_price_data(cfg["ticker"], lookback_days=lookback)
+    df = compute_indicators(df)
+    df["Stage"] = classify_stages(df)
+    window_df = df.loc[start:end]
+
+    counts = window_df["Stage"].dropna().astype(int).value_counts()
+    if counts.empty:
+        path = _save_debug(window_df, cfg["name"], ["Close","SMA200","Slope200","Stage"])
+        pytest.fail(f"No stage data in window. Debug CSV: {path}")
+
+    most_stage = int(counts.idxmax())
+    stage_ratio = counts.get(exp["stage"], 0) / counts.sum()
+    if most_stage != exp["stage"] or stage_ratio < exp["min_ratio"]:
+        path = _save_debug(window_df, cfg["name"], ["Close","SMA200","Slope200","Stage"])
+        pytest.fail(
+            "most_stage={ms}, stage{st}_ratio={r:.2%}, counts={c}. Debug CSV: {p}".format(
+                ms=most_stage, st=exp["stage"], r=stage_ratio, c=counts.to_dict(), p=path
+            )
+        )
+
+
+@pytest.mark.parametrize("cfg", GOLDEN_WINDOWS, ids=[w["name"] for w in GOLDEN_WINDOWS])
+def test_golden_windows(cfg: dict) -> None:
+    if "years" in cfg:
+        _run_continuity(cfg)
+    else:
+        _run_stage_window(cfg)


### PR DESCRIPTION
## Summary
- add development dependencies for running regression tests
- define golden windows for NVDA continuity and AAPL Stage 4
- implement pytest verifying data continuity and stage majority with debug artifacts
- document how to run the test suite

## Testing
- `python -m pip install -r requirements-dev.txt`
- `pytest -q` *(fails: No data returned from Yahoo Finance)*

------
https://chatgpt.com/codex/tasks/task_e_68997f0cef70832a812ec05e0c7d340f