### PR TITLE
Handle ambiguous stage-3 cases and expand usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 Streamlit application for Minervini-style market stage classification over the
 most recent year.
 
+## What it does
+
+The `stage_app` package downloads daily OHLCV data via `yfinance`, computes
+common moving averages (25/50/150/200), 52‑week high/low and the slope of the
+200‑day average, and finally labels each day with one of Mark Minervini's
+four market stages:
+
+| Stage | Meaning (simplified) | Colour |
+|-------|---------------------|--------|
+| 1     | Below a flat/upward 200‑MA   | gray   |
+| 2     | Above a rising 200‑MA        | green  |
+| 3     | Above a falling 200‑MA       | orange |
+| 4     | Below a falling 200‑MA       | red    |
+
+See `stage_app/stage.py` for the exact rules.
+
 ## Quick start
 
 ```bash
@@ -17,6 +33,22 @@ streamlit run stage_app/app.py
 ```bash
 python -m stage_app.cli classify --ticker SPY --csv-out stages_1y.csv --suppress-warnings
 ```
+
+### Library use
+
+The core functionality is available as a library for use in notebooks or other
+scripts:
+
+```python
+from stage_app.stage import fetch_price_data, compute_indicators, classify_stages
+
+df = fetch_price_data("SPY", lookback_days=380)
+df = compute_indicators(df)
+df["Stage"] = classify_stages(df)
+```
+
+`df` now contains the moving averages and a `Stage` column ready for analysis
+or charting.
 ## Run tests
 ```bash
 python -m venv venv

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -147,8 +147,14 @@ def classify_stages(df: pd.DataFrame, slope_threshold: float = -1e-9) -> pd.Seri
     )
     stage[cond2_strict] = 2
 
-    # Stage 3（50/150の下、200の上、かつ傾き<=0） ← 優先順位を上げる
-    cond3 = (close < sma50) & (close < sma150) & (close >= sma200) & (slope <= slope_threshold)
+    # Stage 3（200MAの上で200MAが下向き）
+    #
+    # 以前は 50MA と 150MA の両方を下回った場合だけ Stage3 と判定していたが、
+    # それでは「200MA の上にいるが、50MA か 150MA のどちらか一方は上回って
+    # いる」という局面が未分類のまま ``NaN`` になってしまうことがあった。
+    # 200MA が下降している限り、そうしたケースも Stage3 とみなして良いため
+    # 判定を広げる。
+    cond3 = (close >= sma200) & (slope <= slope_threshold)
     stage[stage.isna() & cond3] = 3
 
     # Stage 4（200下＆下向き）


### PR DESCRIPTION
## Summary
- Broaden Stage 3 logic to cover any price above a falling 200-day MA, reducing unclassified NaN days
- Document stage rules, CLI and library usage in README for easier onboarding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68998f7fdeb0832aa568f3e3a83b14a4