### PR TITLE
Expose slope smoothing window for stage classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ streamlit run stage_app/app.py
 ## Optional CLI
 
 ```bash
-python -m stage_app.cli classify --ticker SPY --csv-out stages_1y.csv --suppress-warnings
+python -m stage_app.cli classify --ticker SPY --csv-out stages_1y.csv \
+    --slope-smooth-window 5 --suppress-warnings
 ```
 
 ### Library use
@@ -44,7 +45,8 @@ from stage_app.stage import fetch_price_data, compute_indicators, classify_stage
 
 df = fetch_price_data("SPY", lookback_days=380)
 df = compute_indicators(df)
-df["Stage"] = classify_stages(df)
+# ``slope_smooth_window`` controls the rolling mean used for the 200MA slope.
+df["Stage"] = classify_stages(df, slope_smooth_window=5)
 ```
 
 `df` now contains the moving averages and a `Stage` column ready for analysis

--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -114,6 +114,9 @@ def main() -> None:
     label = st.sidebar.selectbox("Ticker", list(CHOICES.keys()), index=0)
     ticker = CHOICES[label]
     years = st.sidebar.number_input("期間（年数）", 1, 10, 1, 1)
+    slope_smooth_window = st.sidebar.number_input(
+        "Slope smoothing window", 1, 50, 5, 1
+    )
     run_btn = st.sidebar.button("Run")
 
     st.sidebar.markdown("### Stage Colors")
@@ -145,7 +148,9 @@ def main() -> None:
 
         # 3) ステージ分類
         with st.spinner("Classifying stages..."):
-            df["Stage"] = classify_stages(df)
+            df["Stage"] = classify_stages(
+                df, slope_smooth_window=int(slope_smooth_window)
+            )
         pbar.progress(int(3 * 100 / steps))
 
         # 4) 描画

--- a/stage_app/cli.py
+++ b/stage_app/cli.py
@@ -17,6 +17,9 @@ def main() -> None:
 def classify(
     ticker: str = typer.Option(..., help="Ticker symbol"),
     csv_out: Path = typer.Option(..., help="Output CSV file"),
+    slope_smooth_window: int = typer.Option(
+        5, "--slope-smooth-window", help="Rolling window to smooth 200MA slope"
+    ),
     suppress_warnings: bool = typer.Option(
         False, "--suppress-warnings", help="Silence warnings"
     ),
@@ -26,7 +29,7 @@ def classify(
         warnings.filterwarnings("ignore")
     data = fetch_price_data(ticker)
     df = compute_indicators(data)
-    df["Stage"] = classify_stages(df)
+    df["Stage"] = classify_stages(df, slope_smooth_window=slope_smooth_window)
     df[["Close", "SMA50", "SMA150", "SMA200", "Stage"]].dropna().to_csv(
         csv_out, index_label="Date"
     )

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -115,12 +115,17 @@ def compute_indicators(data: pd.DataFrame, slope_window: int = 20) -> pd.DataFra
     df["Slope200"] = _sma_slope(df["SMA200"], slope_window)
     return df
 
-def classify_stages(df: pd.DataFrame, slope_threshold: float = -1e-9) -> pd.Series:
+def classify_stages(
+    df: pd.DataFrame,
+    slope_threshold: float = -1e-9,
+    slope_smooth_window: int = 5,
+) -> pd.Series:
     """Minervini 1/2/3/4 判定（Stage3 を優先）。
     優先度: 2(厳格) ＞ 3 ＞ 4 ＞ 1 ＞ 2(基本)
 
     ``slope_threshold`` は微小なノイズで上向き判定になることを防ぐため、
     ごく僅かに負の値をデフォルトとする。
+    ``slope_smooth_window`` は 200MA 傾きの短期平均に利用する窓長。
     """
     df = df.copy()
     if isinstance(df.index, pd.MultiIndex):
@@ -133,7 +138,7 @@ def classify_stages(df: pd.DataFrame, slope_threshold: float = -1e-9) -> pd.Seri
     sma150  = df["SMA150"].squeeze()
     sma200  = df["SMA200"].squeeze()
     # 200日線の傾きは短期平均で平滑化してから符号判定する
-    slope   = df["Slope200"].rolling(5).mean().squeeze()
+    slope   = df["Slope200"].rolling(slope_smooth_window).mean().squeeze()
     high52w = df["High52w"].squeeze()
     low52w  = df["Low52w"].squeeze()
 

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -91,3 +91,23 @@ def test_golden_windows(cfg: dict) -> None:
         _run_continuity(cfg)
     else:
         _run_stage_window(cfg)
+
+
+def test_slope_smooth_window() -> None:
+    idx = pd.date_range("2024-01-01", periods=5)
+    df = pd.DataFrame(
+        {
+            "Close": [110] * 5,
+            "SMA50": [100] * 5,
+            "SMA150": [100] * 5,
+            "SMA200": [100] * 5,
+            "Slope200": [3, 3, 3, -4, -4],
+            "High52w": [120] * 5,
+            "Low52w": [90] * 5,
+        },
+        index=idx,
+    )
+    default_stage = classify_stages(df).iloc[-1]
+    custom_stage = classify_stages(df, slope_smooth_window=3).iloc[-1]
+    assert default_stage == 2
+    assert custom_stage == 3


### PR DESCRIPTION
## Summary
- allow `classify_stages` to accept a `slope_smooth_window` parameter
- wire new option through CLI and Streamlit app
- document and test the adjustable smoothing window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689996faf730832aad3dcb62a75a57be