### PR TITLE
Make warnings suppression opt-in

### DIFF
--- a/stage_app/cli.py
+++ b/stage_app/cli.py
@@ -22,15 +22,21 @@ def classify(
     ),
 ) -> None:
     """Export 1Y stage classification to CSV."""
+    def _run() -> None:
+        data = fetch_price_data(ticker)
+        df = compute_indicators(data)
+        df["Stage"] = classify_stages(df)
+        df[["Close", "SMA50", "SMA150", "SMA200", "Stage"]].dropna().to_csv(
+            csv_out, index_label="Date"
+        )
+        typer.echo(f"Saved {csv_out}")
+
     if suppress_warnings:
-        warnings.filterwarnings("ignore")
-    data = fetch_price_data(ticker)
-    df = compute_indicators(data)
-    df["Stage"] = classify_stages(df)
-    df[["Close", "SMA50", "SMA150", "SMA200", "Stage"]].dropna().to_csv(
-        csv_out, index_label="Date"
-    )
-    typer.echo(f"Saved {csv_out}")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _run()
+    else:
+        _run()
 
 
 if __name__ == "__main__":

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -1,6 +1,3 @@
-import warnings
-warnings.filterwarnings("ignore")
-
 from datetime import datetime, timedelta
 
 import numpy as np


### PR DESCRIPTION
## Summary
- Remove global warnings filter from `stage_app.stage`
- Add warnings context manager in CLI so suppression is optional via `--suppress-warnings`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999800cf78832ab8da4c564173b10e