### PR TITLE
Fix stage classification gaps

### DIFF
--- a/minervini_stage/stage_rules.py
+++ b/minervini_stage/stage_rules.py
@@ -46,8 +46,10 @@ def classify_stage(df: pd.DataFrame, config: StageConfig | None = None) -> pd.Da
     stage[(out["Close"] < out["SMA200"]) & (out["SMA200_slope"] < 0) & ~tt] = 4
 
     cond3 = (
-        (out["Close"] < out["SMA50"]) & (out["Close"] < out["SMA150"])
-        & (out["Close"] >= out["SMA200"]) & (out["SMA200_slope"] <= 0)
+        (out["Close"] >= out["SMA200"]) & (
+            (out["SMA200_slope"] <= cfg.slope_threshold)
+            | ((out["Close"] < out["SMA50"]) & (out["Close"] < out["SMA150"]))
+        )
     )
     stage[cond3 & stage.isna()] = 3
 

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -155,14 +155,15 @@ def classify_stages(
     )
     stage[cond2_strict] = 2
 
-    # Stage 3（200MAの上で200MAが下向き）
+    # Stage 3（200MAの上で Stage2 を満たさないケース）
     #
-    # 以前は 50MA と 150MA の両方を下回った場合だけ Stage3 と判定していたが、
-    # それでは「200MA の上にいるが、50MA か 150MA のどちらか一方は上回って
-    # いる」という局面が未分類のまま ``NaN`` になってしまうことがあった。
-    # 200MA が下降している限り、そうしたケースも Stage3 とみなして良いため
-    # 判定を広げる。
-    cond3 = (close >= sma200) & (slope <= slope_threshold)
+    # 以前は 200MA が下向きの場合にだけ Stage3 としていたが、
+    # 「200MA は上向きだが 50MA と 150MA を同時に下回っている」
+    # 局面が未分類の ``NaN`` になってしまうことがあった。
+    # そうした日も Stage3 として扱い、判定漏れを防ぐ。
+    cond3 = (close >= sma200) & (
+        (slope <= slope_threshold) | ((close < sma50) & (close < sma150))
+    )
     stage[stage.isna() & cond3] = 3
 
     # Stage 4（200下＆下向き）


### PR DESCRIPTION
## Summary
- Broaden Stage3 classification so prices above the 200MA but below both the 50MA and 150MA are not left unlabeled
- Mirror Stage3 update in library `stage_rules`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999b55bc74832ab6e57ffd18d9d7c4