### PR TITLE
Improve stage continuity and Stage 4 classification

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -137,7 +137,7 @@ def main() -> None:
     try:
         # 1) データ取得（表示よりも長めに取得して指標計算に利用）
         with st.spinner("Downloading data..."):
-            lookback_days = int(years * 365 + 300)
+            lookback_days = int(years * 365)
             data = cached_fetch(ticker, lookback_days=lookback_days)
         pbar.progress(int(1 * 100 / steps))
 


### PR DESCRIPTION
## Summary
- fetch extra buffer history for price data to support long-term SMA calculations
- add configurable below-200MA margin rule when classifying Stage 4 and guard Stage 1
- rely on internal buffering in tests and add unit test for margin rule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a68375f4832aa2e15a883be231e4