### PR TITLE
Improve Stage continuity by preserving warm-up data

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -163,7 +163,9 @@ def main() -> None:
                 st.info("まだステージが計算できた行がありません（SMAや200日傾きの計算に十分な日数が必要です）。")
             else:
                 display_end = df_plot.index.max()
-                display_start = display_end - pd.Timedelta(days=365 * years)
+                # Trim only after indicators and stages are computed so the
+                # warm-up period fetched in ``fetch_price_data`` is preserved.
+                display_start = display_end - pd.Timedelta(days=lookback_days)
                 df_plot = df_plot[(df_plot.index >= display_start) & (df_plot.index <= display_end)]
                 fig = build_chart(df_plot, ticker)
                 st.plotly_chart(fig, use_container_width=True)

--- a/tests/test_fetch_price_data.py
+++ b/tests/test_fetch_price_data.py
@@ -6,7 +6,8 @@ from stage_app.stage import fetch_price_data
 
 
 def test_fetch_price_data_flattens_multiindex_columns(monkeypatch):
-    idx = pd.date_range("2023-01-01", periods=252, freq="B")
+    periods = 252 + 220
+    idx = pd.date_range("2023-01-01", periods=periods, freq="B")
     arrays = [["Open", "High", "Low", "Close", "Volume"], ["SPY"]]
     cols = pd.MultiIndex.from_product(arrays, names=["Price", "Ticker"])
     data = pd.DataFrame(np.arange(len(idx) * 5).reshape(len(idx), 5), index=idx, columns=cols)
@@ -15,6 +16,7 @@ def test_fetch_price_data_flattens_multiindex_columns(monkeypatch):
         return data
 
     monkeypatch.setattr(yf, "download", fake_download)
-    df = fetch_price_data("SPY")
+    df = fetch_price_data("SPY", lookback_days=252, calc_lookback_buffer=220)
     assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
-    assert len(df) == 252
+    # Should retain the warm-up rows and not truncate to 252
+    assert len(df) == periods


### PR DESCRIPTION
## Summary
- retain warm-up price history in `fetch_price_data` so long-term indicators can be computed from first visible day
- reduce initial Stage gaps by allowing early SMA slope calculations
- slice chart display to requested period only after indicators and stages are computed

## Testing
- `pytest -q`
- `python - <<'PY'
from stage_app.stage import fetch_price_data, compute_indicators, classify_stages

data = fetch_price_data('NVDA', lookback_days=365)
ind = compute_indicators(data)
ind['Stage'] = classify_stages(ind)
recent = ind.tail(252)
print('NaN ratio:', recent['Stage'].isna().mean())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899deb9cf90832ab0c51f5eee800882