### PR TITLE
Ensure sufficient warm-up data for SMA200 calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ scripts:
 ```python
 from stage_app.stage import fetch_price_data, compute_indicators, classify_stages
 
-df = fetch_price_data("SPY", lookback_days=380)
+# ``fetch_price_data`` automatically grabs additional history (~300 days)
+# so indicator calculations have sufficient warm-up data.
+df = fetch_price_data("SPY", lookback_days=365)
 df = compute_indicators(df)
 # ``slope_smooth_window`` controls the rolling mean used for the 200MA slope.
 df["Stage"] = classify_stages(df, slope_smooth_window=5)

--- a/stage_app/stage.py
+++ b/stage_app/stage.py
@@ -14,7 +14,7 @@ STAGE_COLORS = {1: "gray", 2: "green", 3: "orange", 4: "red"}
 def fetch_price_data(
     ticker: str,
     lookback_days: int = 365,
-    calc_lookback_buffer: int = 220,
+    calc_lookback_buffer: int = 300,
 ) -> pd.DataFrame:
     """Return OHLC data for the requested lookback window.
 
@@ -25,8 +25,12 @@ def fetch_price_data(
     buffer`` specifies how many extra calendar days of history to fetch for
     this warm‑up period.  Callers should perform indicator calculations on
     the full returned frame and only slice to the desired display window at
-    the end.
+    the end.  If a caller provides a smaller buffer, at least 200 days of
+    warm‑up data will still be fetched.
     """
+    if calc_lookback_buffer < 200:
+        calc_lookback_buffer = 200
+
     end = datetime.utcnow()
     start = end - timedelta(days=lookback_days + calc_lookback_buffer)
 


### PR DESCRIPTION
## Summary
- default to fetching an additional ~300 days of price history so SMA200 and slope calculations have adequate warm-up
- document automatic warm-up behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899e1bbc00c832aac918dca1e4d4e0e