### PR TITLE
Increase warm-up window for stage calculations

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -137,8 +137,9 @@ def main() -> None:
     try:
         # 1) データ取得（表示よりも長めに取得して指標計算に利用）
         with st.spinner("Downloading data..."):
-            lookback_days = int(years * 365)
-            data = cached_fetch(ticker, lookback_days=lookback_days)
+            display_days = int(years * 365)
+            fetch_days = display_days + 400
+            data = cached_fetch(ticker, lookback_days=fetch_days)
         pbar.progress(int(1 * 100 / steps))
 
         # 2) 指標計算（Closeベース）
@@ -165,7 +166,7 @@ def main() -> None:
                 display_end = df_plot.index.max()
                 # Trim only after indicators and stages are computed so the
                 # warm-up period fetched in ``fetch_price_data`` is preserved.
-                display_start = display_end - pd.Timedelta(days=lookback_days)
+                display_start = display_end - pd.Timedelta(days=display_days)
                 df_plot = df_plot[(df_plot.index >= display_start) & (df_plot.index <= display_end)]
                 fig = build_chart(df_plot, ticker)
                 st.plotly_chart(fig, use_container_width=True)

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, UTC
 import pandas as pd
 import pytest
 
@@ -28,7 +28,7 @@ def _save_debug(df: pd.DataFrame, name: str, columns: list[str]) -> Path:
 def _run_continuity(cfg: dict) -> None:
     years = cfg["years"]
     exp = cfg["expect"]
-    lookback = years * 365
+    lookback = years * 365 + 400
     df = fetch_price_data(cfg["ticker"], lookback_days=lookback)
     df = compute_indicators(df)
     df["Stage"] = classify_stages(df)
@@ -63,7 +63,8 @@ def _run_stage_window(cfg: dict) -> None:
     exp = cfg["expect"]
     start = pd.to_datetime(window["start"])
     end = pd.to_datetime(window["end"])
-    lookback = (datetime.utcnow().date() - start.date()).days
+    utc_today = datetime.now(UTC).date()
+    lookback = (utc_today - start.date()).days + 400
     df = fetch_price_data(cfg["ticker"], lookback_days=lookback)
     df = compute_indicators(df)
     df["Stage"] = classify_stages(df)


### PR DESCRIPTION
## Summary
- Fetch requested lookback without truncation and validate against SMA200+slope requirements
- Fetch extra history and trim only after indicators/stages are computed in Streamlit app
- Extend test lookback periods with warm-up buffer and use timezone-aware datetimes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899f2536bc0832aa1c588a2a706448a