### PR TITLE
feat: modernize stage app ui

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -1,12 +1,22 @@
-import warnings
-warnings.filterwarnings("ignore")
+"""Streamlit application for visualizing Minervini stages.
 
-from time import perf_counter
+This module builds a small dashboard that downloads OHLC data, computes
+Minervini's moving–average based stages and renders them as a candlestick
+chart.  The UI is intentionally lightweight so that changing the ticker or
+lookback period immediately refreshes the visualisation without the need for a
+"Run" button.
+"""
+
+import warnings
+from datetime import datetime
+from time import perf_counter, time
 
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
+
+warnings.filterwarnings("ignore")
 
 # パッケージ/単体スクリプト両対応
 try:
@@ -25,6 +35,18 @@ except ModuleNotFoundError:
     )
 
 st.set_page_config(layout="wide")
+
+# Custom CSS tweaks for a slightly more modern look-and-feel.
+st.markdown(
+    """
+    <style>
+      .block-container { padding-top: 1rem; }
+      header[data-testid="stHeader"] { backdrop-filter: blur(8px); }
+      footer {visibility: hidden;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 CHOICES = {
     "NVIDIA (NVDA)": "NVDA",
@@ -109,15 +131,28 @@ def build_chart(df: pd.DataFrame, ticker: str) -> go.Figure:
 
 
 def main() -> None:
+    """Render the Stage analysis dashboard."""
+
+    # Debounce support -----------------------------------------------------
+    if "_changed_at" not in st.session_state:
+        st.session_state._changed_at = 0.0
+
+    def _on_change() -> None:
+        """Record the timestamp of the latest widget interaction."""
+        st.session_state._changed_at = time()
+
     # ===== サイドバー =====
     st.sidebar.header("Settings")
-    label = st.sidebar.selectbox("Ticker", list(CHOICES.keys()), index=0)
-    ticker = CHOICES[label]
-    years = st.sidebar.number_input("期間（年数）", 1, 10, 1, 1)
-    slope_smooth_window = st.sidebar.number_input(
-        "Slope smoothing window", 1, 50, 5, 1
+    label = st.sidebar.selectbox(
+        "Ticker", list(CHOICES.keys()), index=0, key="ticker", on_change=_on_change
     )
-    run_btn = st.sidebar.button("Run")
+    ticker = CHOICES[label]
+    years = st.sidebar.number_input(
+        "期間（年数）", 1, 10, 1, 1, key="years", on_change=_on_change
+    )
+    slope_smooth_window = st.sidebar.number_input(
+        "Slope smoothing window", 1, 50, 5, 1, key="slope", on_change=_on_change
+    )
 
     st.sidebar.markdown("### Stage Colors")
     for s, c in STAGE_COLORS.items():
@@ -126,62 +161,100 @@ def main() -> None:
             unsafe_allow_html=True,
         )
 
-    if not run_btn:
-        st.info("左の設定を選んで『Run』を押してください。")
-        return
+    # 軽いデバウンス: 直近 0.25 秒以内の多重トリガーは無視
+    if time() - st.session_state._changed_at < 0.25:
+        st.stop()
 
-    pbar = st.progress(0)
-    steps = 4
-    t0 = perf_counter()
+    plot_area = st.empty()
+    table_area = st.empty()
+    start = perf_counter()
 
     try:
-        # 1) データ取得（表示よりも長めに取得して指標計算に利用）
-        with st.spinner("Downloading data..."):
-            display_days = int(years * 365)
-            fetch_days = display_days + 400
-            data = cached_fetch(ticker, lookback_days=fetch_days)
-        pbar.progress(int(1 * 100 / steps))
+        with plot_area.container():
+            st.caption("Loading…")
+            with st.spinner(f"Loading {ticker}…"):
+                # 1) データ取得（表示よりも長めに取得して指標計算に利用）
+                display_days = int(years * 365)
+                fetch_days = display_days + 400
+                data = cached_fetch(ticker, lookback_days=fetch_days)
 
-        # 2) 指標計算（Closeベース）
-        with st.spinner("Computing indicators..."):
-            df = compute_indicators(data)
-        pbar.progress(int(2 * 100 / steps))
+                # 2) 指標計算（Closeベース）
+                df = compute_indicators(data)
 
-        # 3) ステージ分類
-        with st.spinner("Classifying stages..."):
-            df["Stage"] = classify_stages(
-                df, slope_smooth_window=int(slope_smooth_window)
-            )
-        pbar.progress(int(3 * 100 / steps))
+                # 3) ステージ分類
+                df["Stage"] = classify_stages(
+                    df, slope_smooth_window=int(slope_smooth_window)
+                )
 
-        # 4) 描画
-        with st.spinner("Rendering chart..."):
-            # Stage 列の NaN でフィルタすると初期データが消えてしまうため、
-            # OHLC が揃っているかのみ確認する
-            need = ["Open", "High", "Low", "Close"]
-            df_plot = df.dropna(subset=need).copy()
-            if df_plot.empty:
-                st.info("まだステージが計算できた行がありません（SMAや200日傾きの計算に十分な日数が必要です）。")
-            else:
+                # 4) 描画
+                need = ["Open", "High", "Low", "Close"]
+                df_plot = df.dropna(subset=need).copy()
+                if df_plot.empty:
+                    st.info(
+                        "まだステージが計算できた行がありません（SMAや200日傾きの計算に十分な日数が必要です）。"
+                    )
+                    return
+
                 display_end = df_plot.index.max()
                 # Trim only after indicators and stages are computed so the
                 # warm-up period fetched in ``fetch_price_data`` is preserved.
                 display_start = display_end - pd.Timedelta(days=display_days)
-                df_plot = df_plot[(df_plot.index >= display_start) & (df_plot.index <= display_end)]
+                df_plot = df_plot[
+                    (df_plot.index >= display_start) & (df_plot.index <= display_end)
+                ]
                 fig = build_chart(df_plot, ticker)
-                st.plotly_chart(fig, use_container_width=True)
-                tbl = (
-                    df_plot[["Close", "SMA25", "SMA50", "SMA200", "Stage"]]
-                    .dropna(subset=["SMA25", "SMA50", "SMA200", "Stage"])
-                    .tail(10)
-                )
-                st.dataframe(tbl)
+                fig.update_layout(template="plotly_dark")
 
-        pbar.progress(100)
-        st.write(f"Completed in {perf_counter() - t0:.2f}s")
+        elapsed = perf_counter() - start
+
+        # ===== ヘッダー行 =====
+        header = st.container()
+        with header:
+            left, right = st.columns([0.7, 0.3])
+            with left:
+                st.markdown(f"## {ticker}")
+                st.markdown(
+                    f"<span style='background-color:#444;padding:2px 6px;border-radius:4px;'> {int(years)}Y </span>",
+                    unsafe_allow_html=True,
+                )
+            with right:
+                st.caption(f"{datetime.now():%Y-%m-%d %H:%M:%S} • {elapsed:.2f}s")
+
+        # ===== グラフ描画 =====
+        with plot_area:
+            st.plotly_chart(fig, use_container_width=True)
+
+        # ===== 凡例 =====
+        legend = st.container()
+        with legend:
+            cols = st.columns(len(STAGE_COLORS) + 3)
+            for i, (stage, color) in enumerate(STAGE_COLORS.items()):
+                cols[i].markdown(
+                    f"<div style='display:flex;align-items:center;'>"
+                    f"<span style='width:12px;height:12px;background:{color};"
+                    f"display:inline-block;margin-right:4px;'></span>Stage {stage}</div>",
+                    unsafe_allow_html=True,
+                )
+            cols[len(STAGE_COLORS)].markdown("MA25")
+            cols[len(STAGE_COLORS) + 1].markdown("MA50")
+            cols[len(STAGE_COLORS) + 2].markdown("MA200")
+
+        # ===== テーブル =====
+        tbl = (
+            df_plot[["Close", "SMA25", "SMA50", "SMA200", "Stage"]]
+            .dropna(subset=["SMA25", "SMA50", "SMA200", "Stage"])
+            .tail(10)
+        )
+        with table_area:
+            st.dataframe(tbl)
+
+        st.toast(f"Updated {ticker} ({int(years)}Y)")
 
     except Exception as exc:  # 取得失敗や列欠損などはここで通知
-        st.warning(str(exc))
+        with plot_area.container():
+            st.error("Failed to update chart.")
+            with st.expander("詳細を開く"):
+                st.write(str(exc))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove Run button and trigger automatic redraw when inputs change
- show loading skeleton/spinner, dark theme, and new header/legend layout
- toast on completion and inline error panel for failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a14a714c4832aa3521b52e3478075