### PR TITLE
fix: update Streamlit rerun API

### DIFF
--- a/stage_app/app.py
+++ b/stage_app/app.py
@@ -181,7 +181,7 @@ def main() -> None:
         st.session_state._changed_at = time()
         st.session_state.loading = True
         st.session_state.error = None
-        st.experimental_rerun()
+        st.rerun()
 
     # ===== サイドバー =====
     st.sidebar.header("Settings")
@@ -251,7 +251,7 @@ def main() -> None:
                     st.session_state.error = str(exc)
                 finally:
                     st.session_state.loading = False
-                    st.experimental_rerun()
+                    st.rerun()
         return
 
     # ==== Display phase ==================================================


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_rerun` with `st.rerun`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1d06ccd0832ab73a0f6cde8bbe0c